### PR TITLE
Show command done.

### DIFF
--- a/app/Console/Commands/ShowItems.php
+++ b/app/Console/Commands/ShowItems.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AtlasVG\Console\Commands;
+
+use Doctrine\Common\Inflector\Inflector;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+/**
+ * Class ShowItems
+ * @package AtlasVG\Console\Commands
+ */
+class ShowItems extends \Illuminate\Console\Command
+{
+    /**
+     * The console command name.
+     * @var string
+     */
+    protected $signature = "atlasvg:show {item}";
+
+    /**
+     * The console command description.
+     * @var string
+     */
+    protected $description = "Show the database entries for a given item type i.e: building or pointer.";
+
+    /**
+     * Execute the console command.
+     * @return mixed
+     */
+    public function handle()
+    {
+        try {
+
+            $allowed = ['category', 'building', 'level', 'space', 'pointer'];
+            $itemType = strtolower(Inflector::singularize($this->argument('item')));
+
+            if (!in_array($itemType, $allowed)) {
+                throw new \InvalidArgumentException('Invalid item type, must be one of ' . implode(', ', $allowed));
+            }
+
+            $model = 'AtlasVG\\Models\\' . ucfirst($itemType);
+            if (class_exists($model)) {
+                $headers = (new $model)->getVisible();
+                $data = $model::all()->map(function (Model $model) {
+                    return (new Collection($model->toArray()))
+                        ->map(function ($attribute) {
+                            if (is_array($attribute)) {
+                                if (isset($attribute['id'])) {
+                                    return $attribute['id'];
+                                }
+                                return count($attribute);
+                            }
+                            return substr($attribute, 0, 70);
+                        })
+                        ->toArray();
+                });
+
+                $this->table($headers, $data);
+
+            } else {
+                $this->error('Unable to load the required data model.');
+            }
+
+        } catch (\Exception $e) {
+            $this->error($e->getMessage());
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,5 +13,6 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         \AtlasVG\Console\Commands\Import::class,
         \AtlasVG\Console\Commands\Export::class,
+        \AtlasVG\Console\Commands\ShowItems::class,
     ];
 }

--- a/app/Models/Building.php
+++ b/app/Models/Building.php
@@ -77,7 +77,11 @@ class Building extends Model
      */
     public function getSvgAttribute($svg)
     {
-        return new SimpleXMLIterator($svg, LIBXML_COMPACT);
+        if (isset($svg)) {
+            return new SimpleXMLIterator($svg, LIBXML_COMPACT);
+        }
+
+        return null;
     }
 
     /**
@@ -108,10 +112,12 @@ class Building extends Model
      * Get surroundings map path
      * @return string
      */
-    public function getMapAttribute()
+    public function getMapAttribute($svg)
     {
         $path = resource_path("maps/b{$this->id}.surroundings.svg");
-        $this->svg->saveXML($path);
+        if (isset($this->svg)) {
+            $this->svg->saveXML($path);
+        }
 
         return $this->attributes['map'] = $path;
     }

--- a/app/Models/Building.php
+++ b/app/Models/Building.php
@@ -112,7 +112,7 @@ class Building extends Model
      * Get surroundings map path
      * @return string
      */
-    public function getMapAttribute($svg)
+    public function getMapAttribute()
     {
         $path = resource_path("maps/b{$this->id}.surroundings.svg");
         if (isset($this->svg)) {

--- a/app/Models/Level.php
+++ b/app/Models/Level.php
@@ -126,7 +126,11 @@ class Level extends Model
      */
     public function getSvgAttribute($svg)
     {
-        return new SimpleXMLIterator($svg, LIBXML_COMPACT);
+        if (isset($svg)) {
+            return new SimpleXMLIterator($svg, LIBXML_COMPACT);
+        }
+
+        return null;
     }
 
     /**
@@ -177,7 +181,9 @@ class Level extends Model
     public function getMapAttribute()
     {
         $path = resource_path("maps/b{$this->building->id}.l{$this->id}.svg");
-        $this->svg->saveXML($path);
+        if (isset($this->svg)) {
+            $this->svg->saveXML($path);
+        }
 
         return $this->attributes['map'] = $path;
     }

--- a/app/Models/Space.php
+++ b/app/Models/Space.php
@@ -55,6 +55,21 @@ class Space extends Model
     ];
 
     /**
+     * The attributes that should be visible in serialization.
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'type',
+        'data',
+        'x',
+        'y',
+        'width',
+        'height',
+        'radius',
+    ];
+
+    /**
      * Get the level that holds the space
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */


### PR DESCRIPTION
Added `atlasvg:show` command to display internal information of the item in db. The compatible items are:

- Buildings
- Level
- Spaces
- Pointers
- Categorias

```bash
php artisan atlasvg:show buildings|levels|spaces|pointers|categories
```